### PR TITLE
chore: move overrides + normalize gitignore

### DIFF
--- a/romhack/apply_overrides.sh
+++ b/romhack/apply_overrides.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.."; pwd)"
+SRC="$ROOT/romhack/overrides"
+DST="$ROOT/romhack/pokeemerald"
+
+rsync -av --exclude='.git' "$SRC/" "$DST/"
+echo "Overrides applied to submodule."


### PR DESCRIPTION
Move ai_trainer.pory out of submodule, add apply_overrides.sh, and clean up .gitignore.