### PR TITLE
Add BizHawk mailbox bridge scripts and test guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Turn Pokémon (pokeemerald-expansion) into an interview trainer via an emulator�
 ## Architecture
 
 - **ROM (pokeemerald-expansion + Poryscript)**: an NPC sets a "mailbox" in RAM and shows "Connecting...".
-- **Lua (BizHawk or mGBA)**: watches RAM, calls local FastAPI, writes reply back into RAM.
+- **Lua (BizHawk or mGBA)**: watches RAM, calls local FastAPI, writes reply back into RAM. See the `bridge/` directory for emulator-side scripts.
 - **FastAPI server**: serves prompts, hints, and a simple keyword rubric.
 
 ## Quick start (expansion)
@@ -32,14 +32,21 @@ Turn Pokémon (pokeemerald-expansion) into an interview trainer via an emulator�
    ```
 4. Emulator: BizHawk → load ROM → Tools → Lua Console → open `bridge/bizhawk_ai_bridge.lua`.
 
-   * Press **K** to inject a test request.
-   * Dialog appears for MCQ/TF/Short/Code → answer → in-game mailbox gets response.
+   * BizHawk 2.11+ currently exposes no HTTP client inside its Lua sandbox, so API calls will log `API error -1 (No HTTP client available)` until you provide one externally.
+   * Use `bridge/bizhawk_mailbox_test.lua` to inject a single test packet into the mailbox.
 
 ## Notes
 
 * Don’t distribute ROMs. Ship IPS/UPS patches + scripts only.
 
 * If mGBA Lua lacks HTTP, switch to a tiny Python sidecar that reads/writes memory via the emulator's scripting or a TCP socket.
+
+## BizHawk test flow
+
+1. Build the ROM and start the FastAPI server (`./scripts/dev-up.sh`).
+2. In BizHawk: load `pokeemerald.gba`, open Tools → Lua Console, and load `bridge/bizhawk_ai_bridge.lua`.
+3. In the same Lua Console, run `bridge/bizhawk_mailbox_test.lua` to write a test packet at the mailbox address (`0x03005C00`).
+4. Observe the Lua Console logs. Because BizHawk lacks an HTTP client, the bridge reports `API error -1 (No HTTP client available)` while still demonstrating the mailbox read/write loop.
 
 ## Why the expansion fork?
 

--- a/bridge/bizhawk_ai_bridge.lua
+++ b/bridge/bizhawk_ai_bridge.lua
@@ -1,13 +1,14 @@
--- BizHawk-safe AI bridge with HTTP fallbacks (http -> LuaSocket -> curl.exe)
--- Shows ticks so you know it's alive; safe in IWRAM on GBA.
+-- BizHawk AI bridge that polls a mailbox in IWRAM and calls the FastAPI server
 
 --------------------------------------
 -- Config
 --------------------------------------
-local MAILBOX_ADDR = 0x03005C00   -- absolute GBA addr we picked
+local DOMAIN = "IWRAM"
+local BASE   = 0x03000000
+local MAILBOX_ADDR = 0x03005C00
 local ANSWER_MAX   = 64
 local RESP_MAX     = 60
-local API_URL      = "http://192.168.0.160:8000/ai"
+local API_URL      = "http://localhost:8000/ai"
 
 local PROMPT_IDS = {
   [1] = "ARR_001",
@@ -16,104 +17,53 @@ local PROMPT_IDS = {
 --------------------------------------
 -- Memory helpers (BizHawk)
 --------------------------------------
-local function set_domain_iwram()
-  if not memory.usememorydomain then
-    error("This script expects BizHawk (memory.usememorydomain).")
-  end
-  memory.usememorydomain("IWRAM")
+if not memory.usememorydomain then
+  error("This script expects BizHawk (memory.usememorydomain).")
 end
 
-local function rb_off(base, off) return memory.read_u8(base + off) end
-local function wb_off(base, off, v) memory.write_u8(base + off, v) end
+memory.usememorydomain(DOMAIN)
+local mbox_off = MAILBOX_ADDR - BASE
 
-local function rbytes_off(base, off, n)
+local function rb(off)
+  return memory.read_u8(mbox_off + off, DOMAIN)
+end
+
+local function wb(off, v)
+  memory.write_u8(mbox_off + off, v, DOMAIN)
+end
+
+local function rbytes(off, n)
   local t = {}
   for i = 0, n - 1 do
-    t[#t + 1] = string.char(rb_off(base, off + i))
+    t[#t + 1] = string.char(rb(off + i))
   end
   return table.concat(t)
 end
 
-local function wbytes_off(base, off, s)
+local function wbytes(off, s)
   for i = 1, #s do
-    memory.write_u8(base + off + (i - 1), s:byte(i))
+    memory.write_u8(mbox_off + off + (i - 1), s:byte(i), DOMAIN)
   end
 end
 
-local function zstrip(s) return (s or ""):gsub("\0+$", "") end
+local function zstrip(s)
+  return (s or ""):gsub("\0+$", "")
+end
 
 --------------------------------------
--- HTTP helpers (3 fallbacks)
+-- HTTP helpers
 --------------------------------------
-local have_bizhawk_http = (type(http) == "table" and (http.get or http.post))
+local have_comm = type(comm) == "table" and comm.httpPost
 
-local have_luasocket = false
 local socket_http, ltn12
-do
-  local ok1, mod1 = pcall(require, "socket.http")
-  local ok2, mod2 = pcall(require, "ltn12")
-  if ok1 and ok2 then
-    socket_http = mod1
-    ltn12 = mod2
-    have_luasocket = true
-  end
-end
-
-local function post_via_http(url, body)
-  -- BizHawk's 'http' module shape varies; try the common post signature.
-  if not have_bizhawk_http then return nil, "no http module" end
-  local ok, resp = pcall(function()
-    if http.post then
-      return http.post(url, body, { ["Content-Type"] = "application/json" })
-    elseif http.request then
-      return http.request({ url = url, method = "POST", data = body, headers = { ["Content-Type"] = "application/json" } })
-    end
-  end)
-  if not ok then return nil, tostring(resp) end
-  -- Some versions return {statusCode=..., text=...}; others just text
-  if type(resp) == "table" then
-    return tonumber(resp.statusCode or resp.status or 200) or 200, tostring(resp.text or resp.body or "")
-  else
-    return 200, tostring(resp)
-  end
-end
-
-local function post_via_luasocket(url, body)
-  if not have_luasocket then return nil, "no luasocket" end
-  local resp_t = {}
-  local code, code_str = socket_http.request{
-    url = url,
-    method = "POST",
-    headers = { ["Content-Type"] = "application/json",
-                ["Content-Length"] = tostring(#body) },
-    source = ltn12.source.string(body),
-    sink = ltn12.sink.table(resp_t)
-  }
-  if not code then return nil, tostring(code_str) end
-  return tonumber(code) or 0, table.concat(resp_t)
-end
-
-local function esc(s)
-  -- escape for cmd.exe
-  s = s:gsub('"', '\\"')
-  return '"' .. s .. '"'
-end
-
-local function post_via_curl(url, body)
-  -- Windows 10+ has curl.exe in PATH
-  local cmd = 'curl -s -S -o - -w "\\nHTTPSTATUS:%{http_code}" -X POST -H "Content-Type: application/json" --data ' ..
-              esc(body) .. " " .. esc(url)
-  local pipe = io.popen(cmd, "r")
-  if not pipe then return nil, "popen failed" end
-  local out = pipe:read("*a") or ""
-  pipe:close()
-  local body_part, status = out:match("^(.*)HTTPSTATUS:(%d+)%s*$")
-  if not body_part then return nil, "curl parse fail" end
-  return tonumber(status) or 0, body_part
+local ok_http, mod_http = pcall(require, "socket.http")
+local ok_ltn12, mod_ltn12 = pcall(require, "ltn12")
+if ok_http and ok_ltn12 then
+  socket_http = mod_http
+  ltn12 = mod_ltn12
 end
 
 local function to_json(tbl)
-  -- tiny JSON encoder for our simple payload
   local function enc(v)
     local t = type(v)
     if t == "string" then
@@ -124,13 +74,13 @@ local function to_json(tbl)
       return v and "true" or "false"
     elseif t == "table" then
       local parts = {}
-      local is_array = (next(v) == 1) -- cheap guess
+      local is_array = (next(v) == 1)
       if is_array then
-        for i=1,#v do parts[#parts+1] = enc(v[i]) end
+        for i = 1, #v do parts[#parts + 1] = enc(v[i]) end
         return "[" .. table.concat(parts, ",") .. "]"
       else
-        for k,val in pairs(v) do
-          parts[#parts+1] = '"' .. tostring(k) .. '":' .. enc(val)
+        for k, val in pairs(v) do
+          parts[#parts + 1] = '"' .. tostring(k) .. '":' .. enc(val)
         end
         return "{" .. table.concat(parts, ",") .. "}"
       end
@@ -141,41 +91,57 @@ local function to_json(tbl)
   return enc(tbl)
 end
 
+local function post_via_comm(url, body)
+  if not have_comm then return nil, nil, "No comm.httpPost" end
+  local ok, resp = pcall(function()
+    return comm.httpPost(url, body, "application/json")
+  end)
+  if not ok then return nil, nil, tostring(resp) end
+  if type(resp) == "table" then
+    local code = tonumber(resp.StatusCode or resp.status or resp.statusCode or resp.code)
+    local text = resp.Text or resp.text or resp.Body or resp.body
+    return code or 0, text or "", nil
+  end
+  return 200, tostring(resp), nil
+end
+
+local function post_via_luasocket(url, body)
+  if not socket_http or not ltn12 then return nil, nil, "No socket.http" end
+  local resp_t = {}
+  local code, code_str = socket_http.request{
+    url = url,
+    method = "POST",
+    headers = {
+      ["Content-Type"]   = "application/json",
+      ["Content-Length"] = tostring(#body),
+    },
+    source = ltn12.source.string(body),
+    sink   = ltn12.sink.table(resp_t),
+  }
+  if not code then return nil, nil, tostring(code_str) end
+  return tonumber(code) or 0, table.concat(resp_t), nil
+end
+
 local function post_json(url, tbl)
   local body = to_json(tbl)
-  -- try BizHawk http
-  if have_bizhawk_http then
-    local code, text = post_via_http(url, body)
-    if code then return code, text end
-  end
-  -- try LuaSocket
-  if have_luasocket then
-    local code, text = post_via_luasocket(url, body)
-    if code then return code, text end
-  end
-  -- fallback: curl.exe
-  local code, text = post_via_curl(url, body)
-  if code then return code, text end
-  return -1, "No HTTP client available"
+
+  local code, text, err = post_via_comm(url, body)
+  if code then return code, text, err end
+
+  code, text, err = post_via_luasocket(url, body)
+  if code then return code, text, err end
+
+  return -1, nil, "No HTTP client available"
 end
 
 --------------------------------------
 -- Startup
 --------------------------------------
-set_domain_iwram()
-local DOMAIN = memory.getcurrentmemorydomain()
-local base
-if DOMAIN == "IWRAM" then base = 0x03000000
-elseif DOMAIN == "EWRAM" then base = 0x02000000
-else base = 0 end
-
-local mbox_off = MAILBOX_ADDR - base
 console.clear()
 console.log(string.format(
   "AI bridge started. Domain=%s base=%08X mailbox=%08X (offset %d) RESP_MAX=%d",
-  DOMAIN, base, MAILBOX_ADDR, mbox_off, RESP_MAX))
+  DOMAIN, BASE, MAILBOX_ADDR, mbox_off, RESP_MAX))
 
--- simple tick so we know it’s alive
 local tick = 0
 local function heartbeat()
   tick = tick + 1
@@ -188,29 +154,37 @@ end
 -- Main loop
 --------------------------------------
 while true do
-  -- read flag
-  local flag = rb_off(mbox_off, 0)
+  local flag = rb(0)
   if flag == 1 then
-    local pidx    = rb_off(mbox_off, 1)
-    local attempt = rb_off(mbox_off, 2)
-    local ans_len = math.min(rb_off(mbox_off, 3), ANSWER_MAX)
-    local answer  = zstrip(rbytes_off(mbox_off, 4, ans_len))
+    local pidx    = rb(1)
+    local attempt = rb(2)
+    local ans_len = math.min(rb(3), ANSWER_MAX)
+    local answer  = zstrip(rbytes(4, ans_len))
     local pid     = PROMPT_IDS[pidx] or "ARR_001"
 
     local payload = { prompt_id = pid, attempt = attempt, answer = answer }
-    local code, body = post_json(API_URL, payload)
-    local reply = "Server?"
+    local code, body, err = post_json(API_URL, payload)
+
+    local reply
     if code == 200 and body then
-      local txt = body:match('"text"%s*:%s*"([^"]+)"')
-      reply = txt or "OK"
+      reply = body:match('"text"%s*:%s*"([^"]+)"') or body
     else
-      reply = "API error " .. tostring(code)
-      if body and #body > 0 then reply = reply .. " (" .. body:gsub("[%c]"," "):sub(1,120) .. ")" end
+      if err then
+        reply = string.format("API error %s (%s)", tostring(code), err)
+      elseif body and #body > 0 then
+        reply = string.format("API error %s (%s)", tostring(code), body:gsub("[%c]", " "):sub(1, 120))
+      else
+        reply = string.format("API error %s", tostring(code))
+      end
     end
 
-    if #reply > RESP_MAX then reply = reply:sub(1, RESP_MAX) end
-    wbytes_off(mbox_off, 68, reply)
-    wb_off(mbox_off, 0, 2) -- response ready
+    if #reply > RESP_MAX then
+      reply = reply:sub(1, RESP_MAX)
+    end
+
+    wbytes(68, reply)
+    wb(0, 2)
+
     console.log(string.format(
       "Processed pidx=%d pid=%s attempt=%d -> code=%s reply='%s'",
       pidx, pid, attempt, tostring(code), reply))

--- a/bridge/bizhawk_mailbox_test.lua
+++ b/bridge/bizhawk_mailbox_test.lua
@@ -1,0 +1,43 @@
+-- Injects a test mailbox packet for BizHawk
+
+local DOMAIN = "IWRAM"
+local BASE   = 0x03000000
+local MAILBOX_ADDR = 0x03005C00
+local ANSWER_MAX   = 64
+
+if not memory.usememorydomain then
+  error("This script expects BizHawk (memory.usememorydomain).")
+end
+
+memory.usememorydomain(DOMAIN)
+local mbox_off = MAILBOX_ADDR - BASE
+
+local function wb(off, v)
+  memory.write_u8(mbox_off + off, v, DOMAIN)
+end
+
+local function wbytes(off, s)
+  for i = 1, #s do
+    memory.write_u8(mbox_off + off + (i - 1), s:byte(i), DOMAIN)
+  end
+end
+
+console.log(string.format("Injecting test packet at mailbox=%08X", MAILBOX_ADDR))
+
+-- clear the mailbox region (~100 bytes)
+for i = 0, 99 do
+  wb(i, 0)
+end
+
+local pidx    = 1
+local attempt = 1
+local answer  = "test"
+local ans_len = math.min(#answer, ANSWER_MAX)
+
+wb(1, pidx)
+wb(2, attempt)
+wb(3, ans_len)
+wbytes(4, answer:sub(1, ans_len))
+wb(0, 1)
+
+console.log(string.format("Test packet injected: pidx=%d attempt=%d answer='%s'", pidx, attempt, answer))


### PR DESCRIPTION
## Summary
- rewrite the BizHawk AI bridge to poll the fixed IWRAM mailbox, post prompt data to the FastAPI server, and return truncated replies with logging
- add a BizHawk Lua helper that injects a known mailbox packet for quick tests
- document the bridge scripts and BizHawk test flow, including the current lack of an HTTP client in BizHawk Lua

## Testing
- not run (not requested)